### PR TITLE
fix: regexp and mulExpr parse error

### DIFF
--- a/jsx-antlr-syntax/src/main/antlr3/net/vvakame/jsx/antlr/JSX.g
+++ b/jsx-antlr-syntax/src/main/antlr3/net/vvakame/jsx/antlr/JSX.g
@@ -428,7 +428,7 @@ primaryExpr
 	|	'(' expr ')'
 	|	string
 	|	numberLiteral
-	|	REGEXP_LITERAL
+	|	regexp_literal
 	;
 
 // https://github.com/jsx/JSX/blob/4053b064a59c387dfcfcc9eb3fbd85750cc0a658/src/parser.js#L2600
@@ -512,17 +512,17 @@ SINGLE_QUOTED
 	;
 
 fragment
-CHAR_EXCLUDE_REGEXP_SPECIAL
+char_exclude_regexp_special
 	:	~('/' | '\\')
 	;
 
 fragment
-REGEXP_CHARS
-	:	CHAR_EXCLUDE_REGEXP_SPECIAL* ('\\' . CHAR_EXCLUDE_REGEXP_SPECIAL*)*
+regexp_chars
+	:	char_exclude_regexp_special* ('\\' . char_exclude_regexp_special*)*
 	;
 
-REGEXP_LITERAL
-	:	'/' REGEXP_CHARS '/' ('m' | 'g' | 'i')*
+regexp_literal
+	:	'/' regexp_chars '/' IDENT?
 	;
 
 

--- a/jsx-antlr-syntax/src/test/java/net/vvakame/jsx/antlr/SyntaxTest.java
+++ b/jsx-antlr-syntax/src/test/java/net/vvakame/jsx/antlr/SyntaxTest.java
@@ -60,13 +60,6 @@ public class SyntaxTest {
 				"JSX/t/optimize/", "JSX/t/source-map/" };
 
 		List<String> ignoreFiles = Arrays.asList(new String[] {
-				// FIXME file contains '/', ANTLR parse '?'==EOF. why?
-				"run/003.binaryops.jsx",
-				"run/021.issue1.jsx",
-				"run/126.fused-assign-number-to-int.todo.jsx",
-				"run/170.cast-int-in-return.jsx",
-				"run/171.fused-div-of-int.jsx",
-
 				// FIXME unknown???
 				"run/078.bitnot.jsx", "run/137.same-pred-op-with-parens.jsx",
 				"lib/005.builtins.jsx",


### PR DESCRIPTION
Becase ANTLR's lexer uses longest match string as token,
`REGEXP_LITERAL` always eat '/'.

By changing `regexp_literal` from token to rule,
we decide a usage of '/' at parsing phase, not lexing phase.
