### PR TITLE
Fix PEG-rule for as-syntax

### DIFF
--- a/jsx-peg-syntax/src/main/peg/JSX.peg
+++ b/jsx-peg-syntax/src/main/peg/JSX.peg
@@ -175,7 +175,7 @@ whileStatement
 // https://github.com/jsx/JSX/blob/4053b064a59c387dfcfcc9eb3fbd85750cc0a658/src/parser.js#L1809
 forStatement
 	=	forInStatement
-	/	LPAR (expr / VAR variableDeclarations)? SEMI expr? SEMI expr? RPAR subStatements
+	/	LPAR (VAR variableDeclarations / expr)? SEMI expr? SEMI expr? RPAR subStatements
 	;
 
 // https://github.com/jsx/JSX/blob/4053b064a59c387dfcfcc9eb3fbd85750cc0a658/src/parser.js#L1866
@@ -399,9 +399,9 @@ primaryExpr
 	/	LWING hashLiteral
 	/	LPAR expr RPAR
 	/	numberLiteral
+	/	&ident objectTypeDeclaration
 	/	string
 	/	regexpLiteral
-	/	ident objectTypeDeclaration
 	;
 
 // https://github.com/jsx/JSX/blob/4053b064a59c387dfcfcc9eb3fbd85750cc0a658/src/parser.js#L2600

--- a/jsx-peg-syntax/src/test/java/net/vvakame/jsx/peg/SyntaxTest.java
+++ b/jsx-peg-syntax/src/test/java/net/vvakame/jsx/peg/SyntaxTest.java
@@ -28,7 +28,7 @@ public class SyntaxTest {
 	@Test
 	public void valid() throws IOException {
 		List<String> ignoreFiles = Arrays
-				.asList(new String[] { "/jsx/valid/003.jsx", });
+				.asList(new String[] { });
 
 		for (int i = 1;; i++) {
 			final String fileName = String.format("/jsx/valid/%03d.jsx", i);


### PR DESCRIPTION
- Fix rule order to fit with parser.js(original JSX parser)
- At `_primaryExpr` of parser.js, `ident` for LocalExpression/ClassExpression are reuse. To achive this at PEG, I use lookahead operator.

I confirm tihs change by `mvn test`. :sushi:
